### PR TITLE
Fix vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ cp .env.example .env
 npm run start
 ```
 
+## Deploying to Vercel
+
+The application exports an Express server from `server.js`. Vercel runs this file
+as a serverless function automatically, so you do not need to start the server
+manually. Deploy using the Vercel CLI or through the dashboard:
+
+```bash
+vercel --prod
+```
+
+For local development you can still run:
+
+```bash
+npm start
+```
+
 ## Useful resources
 - [Gemini REST API Docs](https://ai.google.dev/tutorials/rest_quickstart)
 - [Prompt design strategies](https://ai.google.dev/docs/prompt_best_practices)

--- a/server.js
+++ b/server.js
@@ -6,9 +6,13 @@ const path = require('path');
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json()); // دعم JSON
 app.set('json spaces', 2);
-app.listen(9012, () => {
-  console.log(`Server running on port 9012`);
-});
+// Only start the server locally. Vercel handles this automatically.
+if (!process.env.VERCEL) {
+  const port = process.env.PORT || 9012;
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
 const routesDir = path.join(__dirname, 'routes');
 const apiList = [];
 global.t = 'https://takamura-api.joanimi-world.site';


### PR DESCRIPTION
## Summary
- adjust server startup logic so Vercel can handle the Express app
- document Vercel deployment in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c496833488325bab70f114a058b41