### PR TITLE
Update runtime settings for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "Simple Api Rest para Bots - By BrunoSobrino.",
   "private": true,
+  "engines": {
+    "node": "16.x"
+  },
   "main": "server.js",
   "scripts": {
     "start": "node server.js",

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,12 @@
   "builds": [
     {
       "src": "server.js",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": {
+        "includeFiles": [
+          "node_modules/**/*"
+        ]
+      }
     }
   ],
   "routes": [


### PR DESCRIPTION
## Summary
- set Node.js 16.x runtime in `package.json`
- include node modules when deploying to Vercel

## Testing
- `npm install`
- `VERCEL=1 node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684c4b70ff6c8325bb1d1f52b17941df